### PR TITLE
Improve homepage in gemspec

### DIFF
--- a/gem-loaded.gemspec
+++ b/gem-loaded.gemspec
@@ -11,7 +11,7 @@ Gem::Specification.new do |spec|
 
   spec.authors                   =  [ 'Asher' ]
   spec.email                     =  'asher@ridiculouspower.com'
-  spec.homepage                  =  'http://rubygems.org/gems/gem-loaded'
+  spec.homepage                  =  'https://github.com/RidiculousPower/gem-loaded'
 
   # just because we use it as an example
   spec.add_development_dependency   'module-cluster'


### PR DESCRIPTION
Common convention has become to reference the code repo with the gemspec homepage.
